### PR TITLE
try to set MaxConcurrentStreams on http2 conns to 1 million

### DIFF
--- a/h2c/h2c.go
+++ b/h2c/h2c.go
@@ -65,13 +65,13 @@ func (s Server) Serve(l net.Listener) error {
 				return
 			}
 			defer s.closeHijackedConnQuietly(conn)
-			h2cSrv := &http2.Server{}
+			h2cSrv := &http2.Server{MaxConcurrentStreams: 1000000}
 			h2cSrv.ServeConn(conn, &http2.ServeConnOpts{Handler: originalHandler})
 			return
 		}
 		if conn, err := h2cUpgrade(w, r, s.closeHijackedConnQuietly); err == nil {
 			defer s.closeHijackedConnQuietly(conn)
-			h2cSrv := &http2.Server{}
+			h2cSrv := &http2.Server{MaxConcurrentStreams: 1000000}
 			h2cSrv.ServeConn(conn, &http2.ServeConnOpts{Handler: originalHandler})
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -617,7 +617,7 @@ func (s *Server) prepareServer(entryPointName string, entryPoint *configuration.
 	}
 	err = http2.ConfigureServer(srv, &http2.Server{MaxConcurrentStreams: 100000})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("error modifying http2 server: %v", err)
 	}
 
 	return &h2c.Server{

--- a/server/server.go
+++ b/server/server.go
@@ -615,7 +615,7 @@ func (s *Server) prepareServer(entryPointName string, entryPoint *configuration.
 		IdleTimeout:  idleTimeout,
 		ErrorLog:     httpServerLogger,
 	}
-	err = http2.ConfigureServer(srv, http2.Server{MaxConcurrentStreams: 100000})
+	err = http2.ConfigureServer(srv, &http2.Server{MaxConcurrentStreams: 100000})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"x/net/http2"
+	"golang.org/x/net/http2"
 
 	"github.com/armon/go-proxyproto"
 	"github.com/containous/mux"


### PR DESCRIPTION
I ran an `rg` through this repo looking for 'http2.Server' and only came across these two instances.  I _think_ this is where all the http2 logic lives, and this should give us a lot of headroom.