### PR TITLE
init impl for breadcrumbing the service destination, see todo for necessary future changes

### DIFF
--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -11,6 +11,11 @@ import (
 	"golang.org/x/net/http2"
 )
 
+const (
+	BreadCrumbsEnabled          = true // TODO: modify configurations to support changing this value
+	ServiceDestinationUriHeader = "X-Traefik-Dest-Uri"
+)
+
 func newSmartRoundTripper(transport *http.Transport, forwardingTimeouts *dynamic.ForwardingTimeouts) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
 
@@ -41,23 +46,41 @@ func newSmartRoundTripper(transport *http.Transport, forwardingTimeouts *dynamic
 	transport.RegisterProtocol("h2c", transportH2C)
 
 	return &smartRoundTripper{
-		http2: transport,
-		http:  transportHTTP1,
+		http2:           transport,
+		http:            transportHTTP1,
+		emitBreadCrumbs: BreadCrumbsEnabled,
 	}, nil
 }
 
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
 // with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
+// Also emits breadcrumbs
 type smartRoundTripper struct {
-	http2 *http.Transport
-	http  *http.Transport
+	http2           *http.Transport
+	http            *http.Transport
+	emitBreadCrumbs bool // TODO: support enabling via status code
 }
 
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var response *http.Response
+	var err error
+
 	// If we have a connection upgrade, we don't use HTTP/2
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
-		return m.http.RoundTrip(req)
+		response, err = m.http.RoundTrip(req)
+	} else {
+		response, err = m.http2.RoundTrip(req)
+	}
+	if err != nil {
+		return response, err
 	}
 
-	return m.http2.RoundTrip(req)
+	if m.emitBreadCrumbs {
+		emitBreadCrumbs(req, response)
+	}
+	return response, err
+}
+
+func emitBreadCrumbs(req *http.Request, response *http.Response) {
+	response.Header.Add(ServiceDestinationUriHeader, req.URL.String())
 }


### PR DESCRIPTION
### Motivation
- For debugging where a request is proxied to by traefik

### More
- [] Added service destination to the response headers under X-Traefik-Dest-Uri 
- [] Allow for configuring the breadcrumb
