### PR TITLE
Breadcrumbs 1.7

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -75,41 +75,42 @@ type GlobalConfiguration struct {
 	LogLevel                  string            `short:"l" description:"Log level" export:"true"`
 	EntryPoints               EntryPoints       `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'" export:"true"`
 	Cluster                   *types.Cluster
-	Constraints               types.Constraints       `description:"Filter services by constraint, matching with service tags" export:"true"`
-	ACME                      *acme.ACME              `description:"Enable ACME (Let's Encrypt): automatic SSL" export:"true"`
-	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint" export:"true"`
-	ProvidersThrottleDuration flaeg.Duration          `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time." export:"true"`
-	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used" export:"true"`
-	IdleTimeout               flaeg.Duration          `description:"(Deprecated) maximum amount of time an idle (keep-alive) connection will remain idle before closing itself." export:"true"` // Deprecated
-	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification" export:"true"`
-	RootCAs                   tls.FilesOrContents     `description:"Add cert file for self-signed certificate"`
-	Retry                     *Retry                  `description:"Enable retry sending request if network error" export:"true"`
-	HealthCheck               *HealthCheckConfig      `description:"Health check parameters" export:"true"`
-	RespondingTimeouts        *RespondingTimeouts     `description:"Timeouts for incoming requests to the Traefik instance" export:"true"`
-	ForwardingTimeouts        *ForwardingTimeouts     `description:"Timeouts for requests forwarded to the backend servers" export:"true"`
-	AllowMinWeightZero        bool                    `description:"Allow weight to take 0 as minimum real value." export:"true"`         // Deprecated
-	KeepTrailingSlash         bool                    `description:"Do not remove trailing slash." export:"true"`                         // Deprecated
-	Web                       *WebCompatibility       `description:"(Deprecated) Enable Web backend with default settings" export:"true"` // Deprecated
-	Docker                    *docker.Provider        `description:"Enable Docker backend with default settings" export:"true"`
-	File                      *file.Provider          `description:"Enable File backend with default settings" export:"true"`
-	Marathon                  *marathon.Provider      `description:"Enable Marathon backend with default settings" export:"true"`
-	Consul                    *consul.Provider        `description:"Enable Consul backend with default settings" export:"true"`
-	ConsulCatalog             *consulcatalog.Provider `description:"Enable Consul catalog backend with default settings" export:"true"`
-	Etcd                      *etcd.Provider          `description:"Enable Etcd backend with default settings" export:"true"`
-	Zookeeper                 *zk.Provider            `description:"Enable Zookeeper backend with default settings" export:"true"`
-	Boltdb                    *boltdb.Provider        `description:"Enable Boltdb backend with default settings" export:"true"`
-	Kubernetes                *kubernetes.Provider    `description:"Enable Kubernetes backend with default settings" export:"true"`
-	Mesos                     *mesos.Provider         `description:"Enable Mesos backend with default settings" export:"true"`
-	Eureka                    *eureka.Provider        `description:"Enable Eureka backend with default settings" export:"true"`
-	ECS                       *ecs.Provider           `description:"Enable ECS backend with default settings" export:"true"`
-	Rancher                   *rancher.Provider       `description:"Enable Rancher backend with default settings" export:"true"`
-	DynamoDB                  *dynamodb.Provider      `description:"Enable DynamoDB backend with default settings" export:"true"`
-	ServiceFabric             *servicefabric.Provider `description:"Enable Service Fabric backend with default settings" export:"true"`
-	Rest                      *rest.Provider          `description:"Enable Rest backend with default settings" export:"true"`
-	API                       *api.Handler            `description:"Enable api/dashboard" export:"true"`
-	Metrics                   *types.Metrics          `description:"Enable a metrics exporter" export:"true"`
-	Ping                      *ping.Handler           `description:"Enable ping" export:"true"`
-	HostResolver              *HostResolverConfig     `description:"Enable CNAME Flattening" export:"true"`
+	Constraints               types.Constraints        `description:"Filter services by constraint, matching with service tags" export:"true"`
+	ACME                      *acme.ACME               `description:"Enable ACME (Let's Encrypt): automatic SSL" export:"true"`
+	DefaultEntryPoints        DefaultEntryPoints       `description:"Entrypoints to be used by frontends that do not specify any entrypoint" export:"true"`
+	ProvidersThrottleDuration flaeg.Duration           `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time." export:"true"`
+	MaxIdleConnsPerHost       int                      `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used" export:"true"`
+	IdleTimeout               flaeg.Duration           `description:"(Deprecated) maximum amount of time an idle (keep-alive) connection will remain idle before closing itself." export:"true"` // Deprecated
+	InsecureSkipVerify        bool                     `description:"Disable SSL certificate verification" export:"true"`
+	RootCAs                   tls.FilesOrContents      `description:"Add cert file for self-signed certificate"`
+	Retry                     *Retry                   `description:"Enable retry sending request if network error" export:"true"`
+	HealthCheck               *HealthCheckConfig       `description:"Health check parameters" export:"true"`
+	RespondingTimeouts        *RespondingTimeouts      `description:"Timeouts for incoming requests to the Traefik instance" export:"true"`
+	ForwardingTimeouts        *ForwardingTimeouts      `description:"Timeouts for requests forwarded to the backend servers" export:"true"`
+	AllowMinWeightZero        bool                     `description:"Allow weight to take 0 as minimum real value." export:"true"`         // Deprecated
+	KeepTrailingSlash         bool                     `description:"Do not remove trailing slash." export:"true"`                         // Deprecated
+	Web                       *WebCompatibility        `description:"(Deprecated) Enable Web backend with default settings" export:"true"` // Deprecated
+	Docker                    *docker.Provider         `description:"Enable Docker backend with default settings" export:"true"`
+	File                      *file.Provider           `description:"Enable File backend with default settings" export:"true"`
+	Marathon                  *marathon.Provider       `description:"Enable Marathon backend with default settings" export:"true"`
+	Consul                    *consul.Provider         `description:"Enable Consul backend with default settings" export:"true"`
+	ConsulCatalog             *consulcatalog.Provider  `description:"Enable Consul catalog backend with default settings" export:"true"`
+	Etcd                      *etcd.Provider           `description:"Enable Etcd backend with default settings" export:"true"`
+	Zookeeper                 *zk.Provider             `description:"Enable Zookeeper backend with default settings" export:"true"`
+	Boltdb                    *boltdb.Provider         `description:"Enable Boltdb backend with default settings" export:"true"`
+	Kubernetes                *kubernetes.Provider     `description:"Enable Kubernetes backend with default settings" export:"true"`
+	Mesos                     *mesos.Provider          `description:"Enable Mesos backend with default settings" export:"true"`
+	Eureka                    *eureka.Provider         `description:"Enable Eureka backend with default settings" export:"true"`
+	ECS                       *ecs.Provider            `description:"Enable ECS backend with default settings" export:"true"`
+	Rancher                   *rancher.Provider        `description:"Enable Rancher backend with default settings" export:"true"`
+	DynamoDB                  *dynamodb.Provider       `description:"Enable DynamoDB backend with default settings" export:"true"`
+	ServiceFabric             *servicefabric.Provider  `description:"Enable Service Fabric backend with default settings" export:"true"`
+	Rest                      *rest.Provider           `description:"Enable Rest backend with default settings" export:"true"`
+	API                       *api.Handler             `description:"Enable api/dashboard" export:"true"`
+	Metrics                   *types.Metrics           `description:"Enable a metrics exporter" export:"true"`
+	Ping                      *ping.Handler            `description:"Enable ping" export:"true"`
+	HostResolver              *HostResolverConfig      `description:"Enable CNAME Flattening" export:"true"`
+	BreadCrumbs               *types.BreadCrumbsConfig `description:"Configure emitting of breadcrumbs" export:"true"`
 }
 
 // WebCompatibility is a configuration to handle compatibility with deprecated web provider options

--- a/integration/log_rotation_test.go
+++ b/integration/log_rotation_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package integration

--- a/provider/acme/local_store_unix.go
+++ b/provider/acme/local_store_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package acme

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,7 @@ func NewServer(globalConfiguration configuration.GlobalConfiguration, provider p
 		log.Errorf("failed to create HTTP transport: %v", err)
 	}
 
-	server.defaultForwardingRoundTripper, err = newSmartRoundTripper(transport)
+	server.defaultForwardingRoundTripper, err = newSmartRoundTripper(transport, globalConfiguration.BreadCrumbs)
 	if err != nil {
 		log.Errorf("Failed to create HTTP transport: %v", err)
 	}

--- a/server/server_loadbalancer.go
+++ b/server/server_loadbalancer.go
@@ -227,7 +227,7 @@ func (s *Server) configureLBServers(lb healthcheck.BalancerHandler, backend *typ
 
 // getRoundTripper will either use server.defaultForwardingRoundTripper or create a new one
 // given a custom TLS configuration is passed and the passTLSCert option is set to true.
-func (s *Server) getRoundTripper(entryPointName string, passTLSCert bool, tls *traefiktls.TLS) (http.RoundTripper, error) {
+func (s *Server) getRoundTripper(entryPointName string, passTLSCert bool, tls *traefiktls.TLS, breadCrumbsConfig *types.BreadCrumbsConfig) (http.RoundTripper, error) {
 	if !passTLSCert {
 		return s.defaultForwardingRoundTripper, nil
 	}
@@ -245,7 +245,7 @@ func (s *Server) getRoundTripper(entryPointName string, passTLSCert bool, tls *t
 
 	transport.TLSClientConfig = tlsConfig
 
-	smartTransport, err := newSmartRoundTripper(transport)
+	smartTransport, err := newSmartRoundTripper(transport, breadCrumbsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_signals.go
+++ b/server/server_signals.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/server_signals_windows.go
+++ b/server/server_signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package server

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -4,11 +4,16 @@ import (
 	"crypto/tls"
 	"net/http"
 
+	"github.com/traefik/traefik/types"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2"
 )
 
-func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+const (
+	ServiceDestinationUriHeader = "x-roblox-traefik-dest"
+)
+
+func newSmartRoundTripper(transport *http.Transport, config *types.BreadCrumbsConfig) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
 
 	err := http2.ConfigureTransport(transport)
@@ -17,27 +22,55 @@ func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) 
 	}
 
 	return &smartRoundTripper{
-		http2: transport,
-		http:  transportHTTP1,
+		http2:  transport,
+		http:   transportHTTP1,
+		config: config,
 	}, nil
 }
 
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
 // with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
 type smartRoundTripper struct {
-	http2 *http.Transport
-	http  *http.Transport
+	http2  *http.Transport
+	http   *http.Transport
+	config *types.BreadCrumbsConfig
 }
 
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var response *http.Response
+	var err error
+
 	// If we have a connection upgrade, we don't use HTTP2
 	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
-		return m.http.RoundTrip(req)
+		response, err = m.http.RoundTrip(req)
+	} else {
+		response, err = m.http2.RoundTrip(req)
+	}
+	if err != nil {
+		return response, err
 	}
 
-	return m.http2.RoundTrip(req)
+	if m.config != nil {
+		enabledFlags := [...]bool{
+			false,
+			m.config.Enabled1xx,
+			m.config.Enabled2xx,
+			m.config.Enabled3xx,
+			m.config.Enabled4xx,
+			m.config.Enabled5xx,
+		} // pls golang compiler optimize this :pray:
+		if response.StatusCode >= 100 && response.StatusCode < 600 && enabledFlags[response.StatusCode/100] {
+			emitBreadCrumbs(req, response)
+		}
+	}
+
+	return response, err
 }
 
 func (m *smartRoundTripper) GetTLSClientConfig() *tls.Config {
 	return m.http2.TLSClientConfig
+}
+
+func emitBreadCrumbs(req *http.Request, response *http.Response) {
+	response.Header.Add(ServiceDestinationUriHeader, req.URL.String())
 }

--- a/server/smart_roundtripper.go
+++ b/server/smart_roundtripper.go
@@ -12,14 +12,14 @@ import (
 )
 
 const (
-	ProxyIpHeader               = "x-roblox-traefik-src"
-	ServiceDestinationUriHeader = "x-roblox-traefik-dest"
-	HeaderDelimiter             = ";"
+	proxyIPHeader               = "x-roblox-traefik-src"
+	serviceDestinationURIHeader = "x-roblox-traefik-dest"
+	headerDelimiter             = ";"
 )
 
 var (
-	LocalIp     = ""
-	LocalIpOnce = sync.Once{}
+	localIP     = ""
+	localIPOnce = sync.Once{}
 )
 
 func newSmartRoundTripper(transport *http.Transport, config *types.BreadCrumbsConfig) (http.RoundTripper, error) {
@@ -81,22 +81,22 @@ func (m *smartRoundTripper) GetTLSClientConfig() *tls.Config {
 }
 
 func emitBreadCrumbs(req *http.Request, response *http.Response, config *types.BreadCrumbsConfig) {
-	var proxyIp string
-	if config.ProxyIp == "" {
-		LocalIpOnce.Do(func() {
-			LocalIp = getLocalIP()
+	var proxyIP string
+	if config.ProxyIP == "" {
+		localIPOnce.Do(func() {
+			localIP = getLocalIP()
 		})
-		proxyIp = LocalIp
+		proxyIP = localIP
 	} else {
-		proxyIp = config.ProxyIp
+		proxyIP = config.ProxyIP
 	}
-	appendToHeader(response, ProxyIpHeader, proxyIp)
-	appendToHeader(response, ServiceDestinationUriHeader, req.URL.String())
+	appendToHeader(response, proxyIPHeader, proxyIP)
+	appendToHeader(response, serviceDestinationURIHeader, req.URL.String())
 }
 
 func appendToHeader(response *http.Response, headerKey, headerVal string) {
 	if oldValue := response.Header.Get(headerKey); oldValue != "" {
-		response.Header.Add(headerKey, oldValue+HeaderDelimiter+headerVal)
+		response.Header.Add(headerKey, oldValue+headerDelimiter+headerVal)
 	} else {
 		response.Header.Add(headerKey, headerVal)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -650,3 +650,12 @@ type TLSCLientCertificateDNInfos struct {
 	SerialNumber    bool `description:"Add SerialNumber info in header" json:"serialNumber"`
 	DomainComponent bool `description:"Add Domain Component info in header" json:"domainComponent"`
 }
+
+// BreadCrumbsConfig determines which type of requests should have bread crumbs emitted in the response
+type BreadCrumbsConfig struct {
+	Enabled1xx bool `json:"enabled1xx" description:"Enable emitting of breadcrumb headers on 1xx requests"`
+	Enabled2xx bool `json:"enabled2xx" description:"Enable emitting of breadcrumb headers on 2xx requests"`
+	Enabled3xx bool `json:"enabled3xx" description:"Enable emitting of breadcrumb headers on 3xx requests"`
+	Enabled4xx bool `json:"enabled4xx" description:"Enable emitting of breadcrumb headers on 4xx requests"`
+	Enabled5xx bool `json:"enabled5xx" description:"Enable emitting of breadcrumb headers on 5xx requests"`
+}

--- a/types/types.go
+++ b/types/types.go
@@ -653,7 +653,7 @@ type TLSCLientCertificateDNInfos struct {
 
 // BreadCrumbsConfig determines which type of requests should have bread crumbs emitted in the response
 type BreadCrumbsConfig struct {
-	ProxyIp    string `json:"proxyIp" description:"The ip of the proxy"`
+	ProxyIP    string `json:"proxyIP" description:"The ip of the proxy"`
 	Enabled1xx bool   `json:"enabled1xx" description:"Enable emitting of breadcrumb headers on 1xx requests"`
 	Enabled2xx bool   `json:"enabled2xx" description:"Enable emitting of breadcrumb headers on 2xx requests"`
 	Enabled3xx bool   `json:"enabled3xx" description:"Enable emitting of breadcrumb headers on 3xx requests"`

--- a/types/types.go
+++ b/types/types.go
@@ -653,9 +653,10 @@ type TLSCLientCertificateDNInfos struct {
 
 // BreadCrumbsConfig determines which type of requests should have bread crumbs emitted in the response
 type BreadCrumbsConfig struct {
-	Enabled1xx bool `json:"enabled1xx" description:"Enable emitting of breadcrumb headers on 1xx requests"`
-	Enabled2xx bool `json:"enabled2xx" description:"Enable emitting of breadcrumb headers on 2xx requests"`
-	Enabled3xx bool `json:"enabled3xx" description:"Enable emitting of breadcrumb headers on 3xx requests"`
-	Enabled4xx bool `json:"enabled4xx" description:"Enable emitting of breadcrumb headers on 4xx requests"`
-	Enabled5xx bool `json:"enabled5xx" description:"Enable emitting of breadcrumb headers on 5xx requests"`
+	ProxyIp    string `json:"proxyIp" description:"The ip of the proxy"`
+	Enabled1xx bool   `json:"enabled1xx" description:"Enable emitting of breadcrumb headers on 1xx requests"`
+	Enabled2xx bool   `json:"enabled2xx" description:"Enable emitting of breadcrumb headers on 2xx requests"`
+	Enabled3xx bool   `json:"enabled3xx" description:"Enable emitting of breadcrumb headers on 3xx requests"`
+	Enabled4xx bool   `json:"enabled4xx" description:"Enable emitting of breadcrumb headers on 4xx requests"`
+	Enabled5xx bool   `json:"enabled5xx" description:"Enable emitting of breadcrumb headers on 5xx requests"`
 }


### PR DESCRIPTION
### Motivation
- For debugging where a request is proxied to by traefik

### More
- [x]  Added service destination to the response headers under X-Traefik-Dest-Uri 

- [x] Allow static configuration to restrict emitting breadcrumbs to certain status codes

### Configuration doc
Add the following to the .toml file to only emit on status codes in range [400, 500):
[breadCrumbs]
enabled4xx = true

Add the following to the .toml file to add proxy src ip:
[breadCrumbs]
proxyIp = "192.168.1.1"